### PR TITLE
fix(deploy): corregir defaults de run.yml para multi-participante en …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,16 @@ bitcoin-cli -regtest stop
 
 Bitcoin Core is compiled **without wallet support**. Mining uses `getblocktemplate + bitcoin-util grind + submitblock`. UTXO discovery uses `scantxoutset`.
 
+## Key dependencies
+
+- **embit** — Bitcoin primitives (Script, Transaction, Taproot)
+- **coincurve** — secp256k1 EC operations (used by musig2.py)
+- **pyln-client** — Core Lightning RPC (used by lnrpc.py)
+- **FastAPI / uvicorn** — participant HTTP API
+
 ## Architecture
+
+The protocol has two layers: an **on-chain layer** (Taproot + MuSig2) and an optional **Lightning Network layer** (CLN + hold invoices). The LN layer uses hold invoices so the coordinator never has unilateral access: participants pay hold invoices → coordinator verifies all N HTLCs accepted → pays winner via regular invoice → settles hold invoices. If the coordinator disappears, hold invoice HTLCs time out and refund automatically.
 
 ```
 tanda/
@@ -53,7 +62,8 @@ tanda/
   participant.py        — Participant actions (contribute, nonce gen, sign_claim, HTLC claim, refund)
   rpc.py                — Bitcoin Core JSON-RPC wrapper (wallet-less + wallet paths)
   lnrpc.py              — CLN RPC wrapper over pyln-client unix socket
-  api_participant_ln.py — FastAPI participant server (CLN_RPC_PATH env var, hold invoice endpoints)
+  api_participant.py    — FastAPI participant server (on-chain, env: SK_IDX, SK_SEED, BITCOIND_RPC_URL)
+  api_participant_ln.py — FastAPI participant server (LN, env: CLN_RPC_PATH, hold invoice endpoints)
   ledger.py             — Per-participant debt/pot ledger with JSON persistence
 
 tests/

--- a/deploy/run.yml
+++ b/deploy/run.yml
@@ -15,7 +15,7 @@
 #   N_PARTICIPANTS      — número de participantes
 #   P{i}_URL            — URL de la API del participante i  (http://IP:8080)
 #   P{i}_CLN_HOST       — hostname o IP del nodo CLN del participante i
-#   P{i}_CLN_P2P_PORT   — puerto P2P del nodo CLN del participante i  (default 9735)
+#   P{i}_CLN_P2P_PORT   — puerto P2P del nodo CLN del participante i  (default 9736+i)
 #
 # Variables opcionales:
 #   CONTRIBUTION_SATS   — aportación en sats  (default 10000)
@@ -38,25 +38,25 @@ services:
       INTERACTIVE:         ${INTERACTIVE:-0}
       ROUND:               ${ROUND:-}
 
-      P0_URL:           ${P0_URL:-http://127.0.0.1:8080}
-      P0_CLN_HOST:      ${P0_CLN_HOST:-127.0.0.1}
-      P0_CLN_P2P_PORT:  ${P0_CLN_P2P_PORT:-9735}
+      P0_URL:           ${P0_URL:-http://host.docker.internal:8080}
+      P0_CLN_HOST:      ${P0_CLN_HOST:-host.docker.internal}
+      P0_CLN_P2P_PORT:  ${P0_CLN_P2P_PORT:-9736}
 
-      P1_URL:           ${P1_URL:-http://127.0.0.1:8081}
-      P1_CLN_HOST:      ${P1_CLN_HOST:-127.0.0.1}
-      P1_CLN_P2P_PORT:  ${P1_CLN_P2P_PORT:-9735}
+      P1_URL:           ${P1_URL:-http://host.docker.internal:8081}
+      P1_CLN_HOST:      ${P1_CLN_HOST:-host.docker.internal}
+      P1_CLN_P2P_PORT:  ${P1_CLN_P2P_PORT:-9737}
 
-      P2_URL:           ${P2_URL:-http://127.0.0.1:8082}
-      P2_CLN_HOST:      ${P2_CLN_HOST:-127.0.0.1}
-      P2_CLN_P2P_PORT:  ${P2_CLN_P2P_PORT:-9735}
+      P2_URL:           ${P2_URL:-http://host.docker.internal:8082}
+      P2_CLN_HOST:      ${P2_CLN_HOST:-host.docker.internal}
+      P2_CLN_P2P_PORT:  ${P2_CLN_P2P_PORT:-9738}
 
       P3_URL:           ${P3_URL:-}
       P3_CLN_HOST:      ${P3_CLN_HOST:-}
-      P3_CLN_P2P_PORT:  ${P3_CLN_P2P_PORT:-9735}
+      P3_CLN_P2P_PORT:  ${P3_CLN_P2P_PORT:-}
 
       P4_URL:           ${P4_URL:-}
       P4_CLN_HOST:      ${P4_CLN_HOST:-}
-      P4_CLN_P2P_PORT:  ${P4_CLN_P2P_PORT:-9735}
+      P4_CLN_P2P_PORT:  ${P4_CLN_P2P_PORT:-}
 
     volumes:
       - cln-coordinator-data-coord:/cln/coordinator


### PR DESCRIPTION
…misma PC

Los defaults de P{i}_CLN_P2P_PORT estaban todos en 9735 (puerto del coordinador), causando colisiones cuando hay múltiples participantes. Ahora usan 9736+i, consistente con run_coordinator_ln.py y test_local_multipc.sh. También cambia host default de 127.0.0.1 a host.docker.internal (el container no puede alcanzar el host via loopback).